### PR TITLE
Fix test errors

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
-var CounterApp = artifacts.require('CounterApp.sol')
+var Widgets = artifacts.require('Widgets.sol')
 
 module.exports = function (deployer) {
-  deployer.deploy(CounterApp)
+  deployer.deploy(Widgets)
 }

--- a/test/app.js
+++ b/test/app.js
@@ -1,5 +1,5 @@
-const CounterApp = artifacts.require('Widgets.sol')
+const Widgets = artifacts.require('Widgets.sol')
 
-contract('CounterApp', (accounts) => {
+contract('Widgets', (accounts) => {
   it('should be tested')
 })


### PR DESCRIPTION
The migration and test file were including a contract called `CounterApp`, rather than the one called `Widgets`.